### PR TITLE
Cherry-pick Lodash methods for smaller bundles

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -38,7 +38,6 @@ module.exports = NuxtHelpers([
           exclude: /(node_modules)/
         })
       }
-    },
-    vendor: ['lodash', 'moment']
+    }
   }
 })

--- a/store/consultDesk.js
+++ b/store/consultDesk.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import { assign, isEmpty } from 'lodash'
 import Robin from '~/utils/libcal'
 
 export const state = {
@@ -6,7 +6,7 @@ export const state = {
 
 export const mutations = {
   update (state, data) {
-    _.assign(state, data)
+    assign(state, data)
   }
 }
 
@@ -17,7 +17,7 @@ export const actions = {
     // -- b. cache has expired
     // -- c. the stored change in status has past
     // -- d. the clock has struck midnight (we've crossed over to the next day)
-    if (_.isEmpty(state) || Robin.staleCache(state.updated) || Robin.pastChange(state.statusChange) || Robin.nextDay(state.updated)) {
+    if (isEmpty(state) || Robin.staleCache(state.updated) || Robin.pastChange(state.statusChange) || Robin.nextDay(state.updated)) {
       let feed = await Robin.getHours(payload.desk, undefined, payload.jsonp)
       const libcalStatus = feed.locations[0].times.status
       const allHours = typeof feed.locations[0].times.hours === 'undefined' ? null : feed.locations[0].times.hours

--- a/store/laptops.js
+++ b/store/laptops.js
@@ -1,4 +1,4 @@
-import {$get} from '~/.nuxt-helpers/axios'
+import { $get } from '~/.nuxt-helpers/axios'
 import Batman from '~/utils/libservices'
 
 export const state = {

--- a/store/phoneChargers.js
+++ b/store/phoneChargers.js
@@ -1,5 +1,5 @@
-import _ from 'lodash'
-import {$get} from '~/.nuxt-helpers/axios'
+import { assign } from 'lodash'
+import { $get } from '~/.nuxt-helpers/axios'
 import Batman from '~/utils/libservices'
 
 export const state = {
@@ -9,7 +9,7 @@ export const state = {
 export const mutations = {
   update (state, feed) {
     state.locations[feed.location] = {}
-    _.assign(state.locations[feed.location], feed.availability)
+    assign(state.locations[feed.location], feed.availability)
   }
 }
 

--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -1,4 +1,4 @@
-import {$get} from '~/.nuxt-helpers/axios'
+import { $get } from '~/.nuxt-helpers/axios'
 import moment from 'moment'
 import jsonpPromise from 'jsonp-promise'
 

--- a/utils/libservices.js
+++ b/utils/libservices.js
@@ -1,4 +1,4 @@
-import _ from 'lodash'
+import { filter, size } from 'lodash'
 
 const baseUrl = 'http://mannservices.mannlib.cornell.edu/LibServices/'
 
@@ -14,8 +14,8 @@ export default {
     }
   },
   availableEquipmentType: (list, type) => {
-    return _.size(
-      _.filter(list, {equipmentType: type, dueDate: null})
+    return size(
+      filter(list, {equipmentType: type, dueDate: null})
     )
   }
 }


### PR DESCRIPTION
As it always should have been. Also remove Lodash and Moment from vendor
bundle in Nuxt config.

TODO:

* Review date-fns [1] as potential modular replacement for Moment.

* Refactor libcal and libservices utils to use named exports

[1] https://date-fns.org