### PR TITLE
README note on force deploy of master to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ For detailed explanation on how things work, checkout the [Nuxt.js docs](https:/
    > ```sh
    > $ git push heroku <branch-name>:master
    > ```
+   >
+   > and if you then need to deploy master once again, most likely will need to force:
+   > ```sh
+   > $ git push heroku master --force
+   > ```


### PR DESCRIPTION
Often necessary if testing changes after deploying another branch which
is ahead of master, and therefore results in a non fast-forward merge.