### PR TITLE
Add Olin CoLab to schema #87

### DIFF
--- a/utils/libcal-schema.js
+++ b/utils/libcal-schema.js
@@ -108,6 +108,23 @@ export default {
           ]
         }
       }
+    },
+    olin: {
+      id: 528,
+      hoursId: 2818,
+      // TODO: Allow for URL at category level to override location?
+      url: 'https://spaces.library.cornell.edu/reserve/olincolab',
+      categories: {
+        colab: {
+          id: false,
+          spaces: [
+            {
+              id: 42377,
+              room: 'Olin CoLab'
+            }
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Only space in Olin for now, so not a deal breaker, but schema & logic
might need to be updated down the road to allow for URL at category
level to override location.