### PR TITLE
Remove whileOpen filter (spaces schedule)

### DIFF
--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -82,7 +82,7 @@ const libCal = {
   },
   bookingsParser: function (bookings, room, openingTime, closingTime) {
     const roomAvailability = _(bookings)
-      // Filter bookings by room, status(confirmed), and while open
+      // Filter bookings by room and status(confirmed)
       .filter(function (booking, index, allBookings) {
         const confirmed = booking.status === 'Confirmed'
         const thisRoom = booking.eid === room

--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -86,10 +86,8 @@ const libCal = {
       .filter(function (booking, index, allBookings) {
         const confirmed = booking.status === 'Confirmed'
         const thisRoom = booking.eid === room
-        const whileOpen = moment(booking.fromDate).isSameOrAfter(openingTime) && moment(booking.toDate).isSameOrBefore(closingTime)
         return thisRoom &&
-          confirmed &&
-          whileOpen
+          confirmed
       })
       // Sort by start time
       .sortBy('fromDate')


### PR DESCRIPTION
This is a safeguard that was necessary in the legacy system but we may
be able to live without in the new app. Time will tell, but realized
this was preventing multiple-day reservations from appearing (which
technically shouldn't happen) since our policies disallow it, but case
in point with the interview room moving and Tom reserved it for 1 mo+.

Also, this filter was going to need to be disabled selectively for the
B30 classrooms at the very least since we have a longstanding policy of
allowing reservations in these classrooms when the basement is actually
closed. [1]

[1] cul-it/circ-display@ff893b4