### PR TITLE
Bugfix: Reverse sort spaces in computed property

### DIFF
--- a/pages/_location/spaces/_category.vue
+++ b/pages/_location/spaces/_category.vue
@@ -54,7 +54,7 @@ export default {
       return this.$store.state.hours
     },
     spaces () {
-      return Object.keys(this.$store.state.spaces)
+      return libCal.sortSpaces(Object.keys(this.$store.state.spaces), this.$route.params.category)
     },
     url () {
       return libCal.reserveUrl(this.$route.params.location, this.$route.params.category)

--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -86,6 +86,9 @@ const libCal = {
     let spaces = []
     spacesInCategory
       .forEach(s => spaces.push({ 'id': s.id, 'name': s.room, 'capacity': s.capacity }))
+    return spaces
+  },
+  sortSpaces: (spaces, category) => {
     // REVIEW: How common will this be? Should it be configurable via the schema?
     if (category === 'studyrooms' || category === 'b30') spaces.reverse()
     return spaces


### PR DESCRIPTION
As opposed to attempting to sort as part of the mutation. Not a good
idea when dealing with numeric keys for the store's object, which will
always result in sorting incrementally.

Noticed this bug while working on B30 display and realizing that reverse
was working for B30 classrooms (non numeric key thanks to the leading
"b"), but not working as originally implemented for Mann study rooms.