### PR TITLE
Merge consecutive bookings by same patron

### DIFF
--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -114,6 +114,16 @@ const libCal = {
       })
       // Sort by start time
       .sortBy('fromDate')
+      // Merge consecutive bookings by same patron
+      // -- because LibCal's UI is still perplexing to a significant percentage of users
+      .filter(function (booking, index, allBookings) {
+        const prevEmail = index > 0 ? allBookings[index - 1].email : null
+        if (booking.email === prevEmail) {
+          allBookings[index - 1].toDate = booking.toDate
+          return false
+        }
+        return true
+      })
       // Fill gaps between & pad bookings with available slots
       .flatMap(function (booking, index, allBookings) {
         const paddedBooking = [booking]


### PR DESCRIPTION
This cleans up/unclutters and maximizes screen real estate of the
display. See before/after screenshots in #107.

Bringing back an oldie but goodie from the legacy app. This should no
longer be necessary since the Equipment & Spaces module doesn't split up
every reservation into individual 30-minute bookings as was the case
with the Room Bookings module.

Unfortunately it's become increasingly clear that LibCal's reservation
UI is still perplexing to a significant percentage of users who don't
realize that they can extend the default booking duration when selecting
a time.