### PR TITLE
Vue-loader config for whitespace

### DIFF
--- a/components/CirculationDevice.vue
+++ b/components/CirculationDevice.vue
@@ -4,7 +4,7 @@
       :class="{ unavailable: !count }"
       class="device-count"
     >{{ count }}</span>
-    <span v-html="deviceStatus" /> <!-- eslint-disable-line vue/no-v-html -->
+    <span v-html="deviceStatus" /><!-- eslint-disable-line vue/no-v-html -->
     <span
       :class="{ unavailable: !count }"
       class="available"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -98,6 +98,13 @@ module.exports = {
   ** Build configuration
   */
   build: {
+    loaders: {
+      vue: {
+        compilerOptions: {
+          whitespace: 'condense'
+        }
+      }
+    },
     /*
     ** Run ESLINT on save
     */

--- a/pages/_location/consult/_desk.vue
+++ b/pages/_location/consult/_desk.vue
@@ -18,7 +18,8 @@
       <span
         :class="hours.status"
         class="status__current"
-      >{{ hours.status }}</span> <span class="until knockout">until</span>
+      >{{ hours.status }}</span>
+      <span class="until knockout">until</span>
       <time
         class="status__change"
       >


### PR DESCRIPTION
Noticed slight differences in layout between staging and production.
Turns out it was due to whitespace-only text nodes introduced during
Nuxt 2.x upgrade (#121) which popped up due to change in whitespace
handling introduced in Vue 2.6 [1].

> See vue-loader docs for config options [2]

[1] vuejs/vue@e1abedb
[2] https://vue-loader.vuejs.org/options.html#compileroptions