### PR TITLE
New sign for Uris 108

### DIFF
--- a/utils/schema.js
+++ b/utils/schema.js
@@ -182,6 +182,16 @@ export default {
               room: '4B04'
             }
           ]
+        },
+        interview: {
+          id: false,
+          url: 'https://spaces.library.cornell.edu/reserve/uris-interview',
+          spaces: [
+            {
+              id: 30587,
+              room: 'Uris 108'
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Using main Uris hours and newly minted friendly URL for LibCal
(/uris-interview).