### PR TITLE
Drop old consult desks (career, cu-career, rdmsg)

### DIFF
--- a/pages/_location/consult/_desk.vue
+++ b/pages/_location/consult/_desk.vue
@@ -143,16 +143,6 @@ export default {
       letter-spacing: 15.1vw;
     }
 
-    &.career {
-      letter-spacing: 2.9vw;
-    }
-
-    &.cu-career {
-      padding: .05em 0 0 .04em;
-      font-size: 26vh;
-      letter-spacing: -1vw;
-    }
-
     &.ciser {
       letter-spacing: 9.6vw;
     }
@@ -160,11 +150,6 @@ export default {
     &.knight {
       padding-left: 0;
       letter-spacing: 3vw;
-    }
-
-    &.rdmsg {
-      padding-left: 0;
-      letter-spacing: 5.3vw;
     }
 
     &.reference {

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -1,11 +1,5 @@
 export default {
   desks: {
-    career: {
-      hoursId: 7733,
-      description: [
-        'CALS student services'
-      ]
-    },
     ciser: {
       hoursId: 3016,
       description: []
@@ -14,13 +8,6 @@ export default {
       hoursId: 3017,
       description: [
         'statistical consulting'
-      ]
-    },
-    'cu-career': {
-      hoursId: 7734,
-      description: [
-        'Graduate',
-        'Cornell Career Services'
       ]
     },
     elso: {
@@ -38,12 +25,6 @@ export default {
       description: [
         'writing',
         'walk-in'
-      ]
-    },
-    rdmsg: {
-      hoursId: 3302,
-      description: [
-        'research data management'
       ]
     },
     reference: {


### PR DESCRIPTION
Remove config from schema and associated styles for rendering desk name.
In prep for Fall 2019.