### PR TITLE
Consistent handling of statusChange

### DIFF
--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -208,7 +208,6 @@ const libCal = {
     return signage.capitalize(name.toLowerCase())
   },
   formatStatusChange: function (datetime) {
-    if (!datetime) return 'null' // Catch when status change is undefined (i.e. no closing time set in LibCal hours)
     if (datetime === 'Open 24 hours') return datetime
     const statusChange = datetime === null ? 'no upcoming openings' : moment(datetime).calendar()
     return statusChange === '12:00 am' ? 'Midnight' : statusChange


### PR DESCRIPTION
No longer need such shenanigans like catching when a status change is
undefined (i.e. no closing time set in LibCal hours for 24hr spaces)
since we now set it explicitly to 'Open 24 hours' in such scenarios.