### PR TITLE
New sign for Olin 104

### DIFF
--- a/utils/schema.js
+++ b/utils/schema.js
@@ -137,6 +137,15 @@ export default {
               room: 'Olin CoLab'
             }
           ]
+        },
+        room104: {
+          id: false,
+          spaces: [
+            {
+              id: 51625,
+              room: 'Olin 104'
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
Using main Olin hours and default LibCal friendly URL for Olin location: `/olin`.