### PR TITLE
Drop meta refresh for OKU circ

### DIFF
--- a/pages/oku/_location.vue
+++ b/pages/oku/_location.vue
@@ -28,9 +28,6 @@ export default {
       link: [
         { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Lato:300,400,700' },
         { rel: 'stylesheet', href: 'https://unpkg.com/font-awesome@4.7.0/css/font-awesome.min.css' }
-      ],
-      meta: [
-        { 'http-equiv': 'refresh', content: '300' }
       ]
     }
   },


### PR DESCRIPTION
Thinking this may be responsible for the ridiculous rate of H27 [1]
errors in Heroku since deploying the test instance meant for debugging
network routing between LibServices and Voyager DB.

Originally tested in #132.

[1]: https://devcenter.heroku.com/articles/error-codes#h27-client-request-interrupted