### PR TITLE
Specify today as date for LibCal API hours request

### DIFF
--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -24,7 +24,7 @@ const libCal = {
   api: {
     endpoints: {
       auth: 'libcal/1.1/oauth/token',
-      hours: 'libcal-hours/api_hours_date.php?iid=973&format=json&nocache=1&lid=',
+      hours: 'libcal-hours/api_hours_date.php?iid=973&format=json&nocache=1&date=today&lid=',
       spaces: {
         bookings: 'libcal/1.1/space/bookings?limit=100&'
       }


### PR DESCRIPTION
Something changed today with the somewhat undocumented
api_hours_date.php endpoint [1], which we've been using for years.

Springshare did roll out a release today (2020-02-20) [2] [3] and it does
mention changes to LibCal Hours and the API, but nothing explicitly
about the undocumented Hours endpoints discoverable via the Hours
widgets, so unsure whether this is a feature or a bug.

One thing to note is that the internal API documentation, available from
the admin dashboard of our LibCal instance, now includes an Hours
endpoint, which I don't remember seeing previously. I haven't been
paying close attention to the internal docs, and can't say for sure that
the Hours endpoint was added with this most recent release, but it's
curious that information on this endpoint is nowhere to be found in the
public documentation [4], which was last updated on 2020-01-23.

[1]: https://ask.springshare.com/libcal/faq/1275
[2]: https://ask.springshare.com/springboards/faq/2468
[3]: https://blog.springshare.com/2020/02/14/feb-release/
[4]: https://ask.springshare.com/libcal/faq/1407