### PR TITLE
New sign for building hours & occupancy

### DIFF
--- a/components/HoursStatus.vue
+++ b/components/HoursStatus.vue
@@ -1,0 +1,57 @@
+<template>
+  <div
+    class="hours"
+    :class="size"
+  >
+    <span
+      :class="hours.status"
+      class="hours-status"
+    >{{ hours.status }}</span>
+    <span> until {{ relativeStatusChange }}</span>
+  </div>
+</template>
+
+<script>
+import libCal from '~/utils/libcal'
+
+export default {
+  props: {
+    hours: {
+      type: Object,
+      required: true
+    },
+    size: {
+      type: String,
+      required: false,
+      default: null
+    }
+  },
+  computed: {
+    relativeStatusChange () {
+      return libCal.formatStatusChange(this.hours.statusChange)
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.embiggen {
+  font-size: 8.5em;
+}
+.hours {
+  text-align: center;
+}
+.hours-status {
+  padding: .1em .2em;
+  text-transform: capitalize;
+  border-radius: .3em;
+
+  &.closed {
+    background-color: #b42b5a;
+  }
+
+  &.open {
+    background-color: #30776b;
+  }
+}
+</style>

--- a/components/HoursStatus.vue
+++ b/components/HoursStatus.vue
@@ -36,15 +36,26 @@ export default {
 
 <style lang="scss">
 .embiggen {
-  font-size: 8.5em;
+  font-size: 8.5vw;
 }
 .hours {
   text-align: center;
+
+  &.embiggen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }
 .hours-status {
   padding: .1em .2em;
   text-transform: capitalize;
   border-radius: .3em;
+
+  .embiggen & {
+    margin-bottom: .4em;
+    width: 27vw;
+  }
 
   &.closed {
     background-color: #b42b5a;

--- a/components/LiveOccupancy.vue
+++ b/components/LiveOccupancy.vue
@@ -18,14 +18,16 @@
 
 <script>
 export default {
+  data () {
+    return {
+      occupancy: {}
+    }
+  },
   computed: {
     iconClass () {
       const keepOut = 'max far fa-times-circle'
       const enter = 'fas fa-sign-in-alt'
       return this.vacancy ? enter : keepOut
-    },
-    occupancy () {
-      return this.$store.state.occupancy
     },
     remaining () {
       return this.occupancy.capacity - this.occupancy.current
@@ -38,6 +40,8 @@ export default {
     await this.$store.dispatch('occupancy/fetch', {
       location: this.$route.params.location
     })
+
+    this.occupancy = this.$store.state.occupancy
   },
   mounted () {
     // Check occupancy every two minutes

--- a/components/LiveOccupancy.vue
+++ b/components/LiveOccupancy.vue
@@ -53,7 +53,7 @@ export default {
 <style lang="scss">
   #live-occupancy {
     display: flex;
-    font-size: 13.5vh;
+    font-size: 8.5vw;
     flex-direction: column;
     justify-content: center;
     text-align: center;

--- a/components/LiveOccupancy.vue
+++ b/components/LiveOccupancy.vue
@@ -1,22 +1,37 @@
 <template>
   <div id="live-occupancy">
     <i
-      class="status-icon fas fa-sign-in-alt fa-3x"
+      class="status-icon fa-3x"
+      :class="iconClass"
       aria-hidden="true"
     />
-    <span class="remaining"> {{ remaining }} people may enter</span>
-    <span class="occupancy"> Occupancy {{ occupancy.current }} / Max {{ occupancy.capacity }}</span>
+    <template v-if="vacancy">
+      <span class="remaining"> {{ remaining }} people may enter</span>
+      <span class="occupancy"> Occupancy {{ occupancy.current }} / Max {{ occupancy.capacity }}</span>
+    </template>
+    <template v-else>
+      <span class="remaining">Please do not enter</span>
+      <span class="occupancy">At max capacity</span>
+    </template>
   </div>
 </template>
 
 <script>
 export default {
   computed: {
+    iconClass () {
+      const keepOut = 'max far fa-times-circle'
+      const enter = 'fas fa-sign-in-alt'
+      return this.vacancy ? enter : keepOut
+    },
     occupancy () {
       return this.$store.state.occupancy
     },
     remaining () {
       return this.occupancy.capacity - this.occupancy.current
+    },
+    vacancy () {
+      return this.remaining > 0
     }
   },
   async fetch () {
@@ -50,5 +65,9 @@ export default {
   }
   .status-icon {
     color: #009edd;
+
+    &.max {
+      color: #b42b5a;
+    }
   }
 </style>

--- a/components/LiveOccupancy.vue
+++ b/components/LiveOccupancy.vue
@@ -1,0 +1,54 @@
+<template>
+  <div id="live-occupancy">
+    <i
+      class="status-icon fas fa-sign-in-alt fa-3x"
+      aria-hidden="true"
+    />
+    <span class="remaining"> {{ remaining }} people may enter</span>
+    <span class="occupancy"> Occupancy {{ occupancy.current }} / Max {{ occupancy.capacity }}</span>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    occupancy () {
+      return this.$store.state.occupancy
+    },
+    remaining () {
+      return this.occupancy.capacity - this.occupancy.current
+    }
+  },
+  async fetch () {
+    await this.$store.dispatch('occupancy/fetch', {
+      location: this.$route.params.location
+    })
+  },
+  mounted () {
+    // Check occupancy every two minutes
+    setInterval(() => {
+      this.$store.dispatch('occupancy/fetch', {
+        location: this.$route.params.location
+      })
+    }, 1000 * 120)
+  }
+}
+</script>
+
+<style lang="scss">
+  #live-occupancy {
+    display: flex;
+    font-size: 13.5vh;
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+  }
+  .occupancy {
+    margin-top: .5em;
+    font-size: .5em;
+    font-weight: 200;
+  }
+  .status-icon {
+    color: #009edd;
+  }
+</style>

--- a/pages/_location/building.vue
+++ b/pages/_location/building.vue
@@ -6,6 +6,11 @@
         v-if="hours.status === 'open'"
         :hours="hours"
       />
+      <!--
+        Need the third child to keep the grid happy
+        TODO: Will refactor when converting header to own component
+      -->
+      <span v-else />
       <!-- eslint-disable vue/no-v-html -->
       <time
         class="spaces__time"

--- a/pages/_location/building.vue
+++ b/pages/_location/building.vue
@@ -1,0 +1,177 @@
+<template>
+  <div class="spaces">
+    <header class="spaces__datetime">
+      <time class="spaces__date">{{ currentDate }}</time>
+      <hours-status
+        v-if="hours.status === 'open'"
+        :hours="hours"
+      />
+      <!-- eslint-disable vue/no-v-html -->
+      <time
+        class="spaces__time"
+        v-html="currentTime"
+      />
+      <!-- eslint-enable vue/no-v-html -->
+    </header>
+
+    <div class="content">
+      <hours-status
+        v-if="hours.status === 'closed'"
+        :hours="hours"
+        size="embiggen"
+      />
+
+      <live-occupancy
+        v-else
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import moment from 'moment'
+import { mapState } from 'vuex'
+import signage from '~/utils/core'
+import HoursStatus from '~/components/HoursStatus'
+import LiveOccupancy from '~/components/LiveOccupancy'
+
+export default {
+  head () {
+    return {
+      title: signage.capitalize(this.$route.params.location) + ' - Hours',
+      link: [
+        { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css?family=Lato:300,400,700' },
+        // TODO: Use packages for official Vue.js component
+        // -- https://fontawesome.com/how-to-use/on-the-web/using-with/vuejs
+        { rel: 'stylesheet', href: 'https://use.fontawesome.com/releases/v5.2.0/css/all.css', integrity: 'sha384-hWVjflwFxL6sNzntih27bfxkr27PmbbK/iSvJ+a4+0owXq79v+lsFkW54bOGbiDQ', crossorigin: 'anonymous' }
+      ]
+    }
+  },
+  components: {
+    HoursStatus: HoursStatus,
+    LiveOccupancy: LiveOccupancy
+  },
+  computed: {
+    ...mapState({
+      currentDate: state => moment(state.time.now).format('ddd D'),
+      currentTime: state => moment(state.time.now).format('h[<span class="blink">:</span>]mm A')
+    }),
+    hours () {
+      return this.$store.state.hours
+    }
+  },
+  fetch: async ({ store, params }) => {
+    await store.dispatch('hours/fetch', {
+      location: params.location,
+      category: params.category
+    })
+  },
+  mounted () {
+    // Sync current time every 10 seconds
+    // -- ideally, this would happen within the store itself (as part of the action),
+    // -- but encountered a bug when attempting this via Nuxt. No issue in vanilla Vue.
+    setInterval(() => {
+      this.$store.dispatch('time/sync')
+    }, 1000 * 10)
+
+    // Update hours every 30 seconds
+    setInterval(() => {
+      this.$store.dispatch('hours/fetch', {
+        location: this.$route.params.location,
+        category: this.$route.params.category
+      })
+    }, 1000 * 30)
+  }
+}
+</script>
+
+<style lang="scss">
+// TODO: DRY util styles & variables
+// -- Most likely via nuxt-sass-resources-loader
+// -- https://github.com/anteriovieira/nuxt-sass-resources-loader
+$columns: 4;
+$sf: 1.43vw;
+
+// Repeat function inspired by native CSS repeat & incomparable Miriam Suzanne
+// -- https://developer.mozilla.org/en-US/docs/Web/CSS/repeat
+// -- https://oddbird.net/susy/docs/config.html#function--susy-repeat
+@function cul-repeat($count, $value: 1) {
+  $return: ();
+
+  @for $i from 1 through $count {
+    $return: join($return, $value);
+  }
+
+  @return $return;
+}
+// TODO: Revisit max number of columns/spaces supported for css-grid
+// Determine column numbers based on spaces count
+// -- currently support up to 4 columns via $columns variable (see above)
+@mixin gen-columns {
+  @for $i from 1 through $columns {
+    &.col-#{$i} {
+      grid-template-columns: cul-repeat($i, 1fr);
+    }
+  }
+}
+
+.blink {
+  animation: blinker infinite cubic-bezier(1.0,0,0,1.0) 1s;
+}
+@keyframes blinker {
+    from {
+        opacity: 1.0;
+    }
+    to {
+        opacity: 0.0;
+    }
+}
+.content {
+  display: flex;
+  flex-flow: column;
+  justify-content: center;
+  height: 92vh;
+}
+.spaces {
+  font-family: 'Lato', sans-serif;
+
+  &__availability {
+    display: grid;
+    clear: both;
+    grid-column-gap: 1.5rem;
+    padding-top: 2.5em;
+
+    @include gen-columns;
+  }
+  &__datetime {
+    display: grid;
+    margin-top: .3em;
+    grid-template-columns: 1fr 4fr 1fr;
+    font-size: 1.8 * $sf;
+
+    // Fallback for older browsers without css-grid
+    // -- primarily early gen iPads in Olin running < iOS 10.3
+    @supports not (display: grid) {
+      display: flex;
+    }
+  }
+  &__date {
+    text-transform: uppercase;
+  }
+  &__reserve-link {
+    text-align: center;
+    color: #fff;
+    text-decoration: none;
+    font-size: .9em;
+
+    // Fallback for older browsers without css-grid
+    // -- primarily early gen iPads in Olin running < iOS 10.3
+    @supports not (display: grid) {
+      flex-grow: 4;
+    }
+  }
+  &__time {
+    text-align: right;
+  }
+}
+</style>

--- a/store/occupancy.js
+++ b/store/occupancy.js
@@ -1,0 +1,30 @@
+import { assign } from 'lodash'
+import schema from '~/utils/schema'
+import sensource from '~/utils/sensource'
+
+export const state = () => ({
+})
+
+export const mutations = {
+  update (state, data) {
+    assign(state, data)
+  }
+}
+
+export const actions = {
+  async fetch ({ commit }, payload) {
+    const spaceCode = schema.locations[payload.location].sensourceId
+
+    await Promise.all([
+      sensource.getOccupancy(this.$axios, spaceCode),
+      sensource.getCapacity(this.$axios, spaceCode)
+    ]).then(function (results) {
+      const occupancy = {
+        current: results[0],
+        capacity: results[1].space.maxCapacity
+      }
+
+      commit('update', occupancy)
+    })
+  }
+}

--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -228,8 +228,10 @@ const libCal = {
     const requestDate = typeof date === 'undefined' ? '' : '&date=' + libCal.formatDate(date)
     if (isDesk) {
       var libcalId = schema.desks[location].hoursId
+    } else if (category) {
+      libcalId = schema.locations[location].categories[category].hoursId
     } else {
-      libcalId = schema.locations[location].categories[category].hoursId || schema.locations[location].hoursId
+      libcalId = schema.locations[location].hoursId
     }
     const url = libCal.api.endpoints.hours + libcalId + requestDate
 

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -139,6 +139,7 @@ export default {
     olin: {
       id: 528,
       hoursId: 2818,
+      sensourceId: 'efc18a38',
       url: 'https://spaces.library.cornell.edu/reserve/olin',
       categories: {
         colab: {
@@ -166,6 +167,7 @@ export default {
     uris: {
       id: 94,
       hoursId: 2830,
+      sensourceId: '9dc56e26',
       url: 'https://spaces.library.cornell.edu/reserve/uris',
       categories: {
         cocktail: {

--- a/utils/schema.js
+++ b/utils/schema.js
@@ -48,6 +48,7 @@ export default {
     mann: {
       id: 96,
       hoursId: 1707,
+      sensourceId: '469b3905',
       url: 'https://mannlib.cornell.edu/reserve',
       categories: {
         b30: {

--- a/utils/sensource.js
+++ b/utils/sensource.js
@@ -1,0 +1,10 @@
+const baseUrl = 'https://display.safespace.io'
+
+export default {
+  getOccupancy: function (axios, spaceCode) {
+    return axios.$get(`${baseUrl}/value/live/${spaceCode}`)
+  },
+  getCapacity: function (axios, spaceCode) {
+    return axios.$get(`${baseUrl}/entity/space/hash/${spaceCode}`)
+  }
+}


### PR DESCRIPTION
When open, live occupancy data is displayed.

Initial implementation for following libraries:
* Mann
* Olin
* Uris

Route is `/{{libraryName}}/building`

> Resolves #181

![Screenshot_2020-09-29 Mann - Hours](https://user-images.githubusercontent.com/409842/94582719-92e13400-024a-11eb-9423-52bf676c7b5d.png)

![Screenshot_2020-09-29 Uris - Hours](https://user-images.githubusercontent.com/409842/94582735-97a5e800-024a-11eb-9ecf-33a828ccdeac.png)

![Screenshot_2020-09-29 Olin - Hours](https://user-images.githubusercontent.com/409842/94582754-9bd20580-024a-11eb-8e61-b7234814a367.png)


