### PR TITLE
Ensure Libcal `lid` is set for hours request

### DIFF
--- a/utils/libcal.js
+++ b/utils/libcal.js
@@ -229,7 +229,7 @@ const libCal = {
     if (isDesk) {
       var libcalId = schema.desks[location].hoursId
     } else if (category) {
-      libcalId = schema.locations[location].categories[category].hoursId
+      libcalId = schema.locations[location].categories[category].hoursId || schema.locations[location].hoursId
     } else {
       libcalId = schema.locations[location].hoursId
     }


### PR DESCRIPTION
For spaces, when categories are involved, we need to be able to use
either the main hours from the parent library, or override using the
category's hours.

Accidentally introduced bug when implementing building occupancy signs
in #186. As a result, all hours were returned and first in the list
(Africana) was being used for all spaces signs.