### PR TITLE
Temporarily disable Olin circ

### DIFF
--- a/pages/oku/_location.vue
+++ b/pages/oku/_location.vue
@@ -47,7 +47,9 @@ export default {
       return this.location + '-display'
     }
   },
-  async fetch ({ store, params }) {
+  async fetch ({ store, params, redirect }) {
+    // Temporarily redirect all requests to the homepage
+    redirect('302', '/')
     await store.dispatch('laptops/fetchStatus', 'olin')
     await store.dispatch('phoneChargers/fetchStatus', 'olin')
     await store.dispatch('laptops/fetchStatus', 'uris')


### PR DESCRIPTION
Redirect (HTTP 302) all requests for OKU Circ to the homepage.

In a holding pattern while we finalize plans to provide data feed of
equipment availability via FOLIO. LibServices has been providing a cache
of Voyager data as it existed on 2021-06-30, but it's about to meet its
demise (DLITSYS-3805).